### PR TITLE
Auto-discover docker containers, allow config, auto update when containers are created/destroyed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,17 @@ ENV VOLUME_DIRECTORY=/opt/server
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y wget openssl build-essential \
     && mkdir -p ${VOLUME_DIRECTORY}/keys \
+    && mkdir -p /opt/configGen \
     && chown -R $CONTAINER_UID:$CONTAINER_GID ${VOLUME_DIRECTORY}/keys \
     && npm install -g log.io pm2 --user 'root' \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists \
     && rm -rf /tmp/*
 
-COPY configGen /opt/configGen
+COPY configGen/package.json opt/configGen/package.json
 RUN cd /opt/configGen && npm i
+
+COPY configGen/*.js /opt/configGen/
 
 ENV DELAYED_START=
 ENV LOGIO_ADMIN_USER=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
-FROM blacklabelops/centos
-MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
+FROM node:6
+MAINTAINER Richard Bateman <taxilian@gmail.com>
 
 # Propert permissions
 ENV CONTAINER_USER logio
-ENV CONTAINER_UID 1000
+ENV CONTAINER_UID 2000
 ENV CONTAINER_GROUP logio
-ENV CONTAINER_GID 1000
+ENV CONTAINER_GID 2000
 
 RUN /usr/sbin/groupadd --gid $CONTAINER_GID logio && \
     /usr/sbin/useradd --uid $CONTAINER_UID --gid $CONTAINER_GID --create-home --shell /bin/bash logio
 
 # install dev tools
 ENV VOLUME_DIRECTORY=/opt/server
-RUN curl --silent --location https://rpm.nodesource.com/setup | bash - && \
-    yum install -y \
-    curl \
-    nodejs \
-    wget \
-    gcc-c++ \
-    openssl \
-    make && \
-    yum clean all && rm -rf /var/cache/yum/* && \
-    mkdir -p ${VOLUME_DIRECTORY}/keys && \
-    chown -R $CONTAINER_UID:$CONTAINER_GID ${VOLUME_DIRECTORY}/keys && \
-    npm install -g log.io --user 'root'
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y wget openssl build-essential \
+    && mkdir -p ${VOLUME_DIRECTORY}/keys \
+    && chown -R $CONTAINER_UID:$CONTAINER_GID ${VOLUME_DIRECTORY}/keys \
+    && npm install -g log.io pm2 --user 'root' \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists \
+    && rm -rf /tmp/*
+
+COPY configGen /opt/configGen
+RUN cd /opt/configGen && npm i
 
 ENV DELAYED_START=
 ENV LOGIO_ADMIN_USER=
@@ -42,5 +41,6 @@ EXPOSE 28778 28777
 
 USER $CONTAINER_UID
 COPY imagescripts/*.sh /opt/logio/
+
 ENTRYPOINT ["/opt/logio/docker-entrypoint.sh"]
 CMD ["logio"]

--- a/configGen/package.json
+++ b/configGen/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "config-gen",
+  "version": "1.0.0",
+  "description": "Generates log.io harvester config files based on running docker containers",
+  "main": "detect_containers.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Richard Bateman <taxilian@gmail.com>",
+  "license": "ISC",
+  "dependencies": {
+    "docker-events": "0.0.2",
+    "dockerode": "^2.5.0",
+    "lodash": "^4.17.4",
+    "node-docker-api": "^1.1.15",
+    "which": "^1.2.14"
+  }
+}

--- a/configGen/run_harvester.js
+++ b/configGen/run_harvester.js
@@ -1,0 +1,139 @@
+// jshint esversion:6
+
+// First check the config
+
+const fs = require('fs');
+const Docker = require('node-docker-api').Docker;
+const DockerEvents = require('docker-events');
+const Dockerode = require('dockerode');
+const which = require('which');
+const { execFile } = require('child_process');
+const _ = require('lodash');
+
+const harvesterPathDfd = new Promise((resolve, reject) => {
+    which('log.io-harvester', (err, path) => err ? reject(err) : resolve(path));
+});
+
+const requireExplicit = process.env.LOGIO_REQUIRE_EXPLICIT == 1;
+const logio_nodeName = process.env.LOGIO_HARVESTER_NODENAME || "node";
+const logio_streamPrefix = process.env.LOGIO_HARVESTER_PREFIX || null;
+const logio_master = process.env.LOGIO_HARVESTER_MASTER_HOST || "logio";
+const logio_masterPort = process.env.LOGIO_HARVESTER_MASTER_HOST || "28777";
+
+const docker_sock = process.env.DOCKER_SOCKET || "/tmp/docker.sock";
+
+const configFilePath = process.env.LOGIO_HARVESTER_CONFIG || "/root/.log.io/harvester.conf"
+
+const dockerode = new Dockerode({socketPath: docker_sock})
+const docker = new Docker({ socketPath: docker_sock });
+
+const dockerEmitter = new DockerEvents({docker: dockerode});
+
+function parseEnv(env) {
+    let out = {};
+    for (let e of env) {
+        let [k, val] = e.split('=', 2);
+        out[k] = val;
+    }
+    return out;
+}
+
+function refreshConfig() {
+
+    // Detect all containers and get their status
+    let containers = docker.container.list().then(list => Promise.all(list.map(c => c.status())));
+
+    // Loop through and collect config information
+    return containers.then(list => {
+        const config = {};
+        for (let c of list) {
+            const cenv = parseEnv(c.data.Config.Env);
+            // if requireExplicit is set then we only include containers with
+            // LOGIO_INCLUDE=1 set in the environment
+            if (requireExplicit && cenv.LOGIO_INCLUDE != 1 || cenv.LOGIO_EXCLUDE == 1) {
+                continue;
+            }
+            // console.log(`env for ${c.data.Name}:`, cenv);
+            let name = cenv.LOGIO_STREAM || c.data.Name.replace(/^\//g, '');
+            if (logio_streamPrefix) { name = `${logio_streamPrefix}${name}`; }
+            let logPath = c.data.LogPath;
+
+            config[name] = {
+                name: name,
+                path: logPath
+            };
+        }
+        return config;
+    }).then(generateConfigFile);
+}
+
+function generateConfigFile(config) {
+    let configFile = `
+exports.config = {
+    nodeName: ${JSON.stringify(logio_nodeName)},
+    logStreams: {`;
+    for (let stream of Object.keys(config)) {
+        configFile += `
+        ${JSON.stringify(stream)}: [${JSON.stringify(config[stream].path)}],`;
+    }
+
+    configFile += `
+    },
+    server: {
+        host: ${JSON.stringify(logio_master)},
+        port: ${logio_masterPort}
+    }
+}
+`;
+    return configFile;
+}
+
+function updateConfig(msg) {
+    if (msg) {
+        console.warn("Message from docker:", msg);
+    }
+    return refreshConfig().then(fileContents => {
+        console.log("Writing new harvester config!", fileContents);
+        fs.writeFileSync(configFilePath, fileContents);
+        return startHarvester();
+    }).catch(err => {
+        console.warn("Error updating config file!", err);
+    });
+}
+updateConfig = _.debounce(updateConfig, 500);
+
+let harvester;
+let harvestPath;
+function startHarvester() {
+    if (harvester) {
+        harvester.kill();
+        harvester = void 0;
+        return;
+    }
+    harvester = execFile(harvestPath, (err, stdout, stderr) => {
+        console.log("Harvester terminated:", err, stderr);
+        setImmediate(startHarvester);
+    });
+    console.log("Re-spawned harvester");
+}
+
+function initHarvester() {
+    harvesterPathDfd.then(hp => {
+        console.log("Found harvester at", hp);
+        harvestPath = hp;
+        return updateConfig();
+    }).catch(err => {
+        console.warn("Could not initalize harvester!", err);
+    });
+}
+
+dockerEmitter.on("connect", () => console.log("Connected to docker, waiting for events"));
+
+dockerEmitter.on("start", updateConfig);
+dockerEmitter.on("stop", updateConfig);
+dockerEmitter.on("die", updateConfig);
+// dockerEmitter.on("_message", message => console.log("got a message from docker: %j", message));
+
+dockerEmitter.start();
+
+initHarvester();

--- a/configGen/run_harvester.js
+++ b/configGen/run_harvester.js
@@ -18,7 +18,7 @@ const requireExplicit = process.env.LOGIO_REQUIRE_EXPLICIT == 1;
 const logio_nodeName = process.env.LOGIO_HARVESTER_NODENAME || "node";
 const logio_streamPrefix = process.env.LOGIO_HARVESTER_PREFIX || null;
 const logio_master = process.env.LOGIO_HARVESTER_MASTER_HOST || "logio";
-const logio_masterPort = process.env.LOGIO_HARVESTER_MASTER_HOST || "28777";
+const logio_masterPort = process.env.LOGIO_HARVESTER_MASTER_PORT || "28777";
 
 const docker_sock = process.env.DOCKER_SOCKET || "/tmp/docker.sock";
 
@@ -114,6 +114,17 @@ function startHarvester() {
         console.log("Harvester terminated:", err, stderr);
         setImmediate(startHarvester);
     });
+    harvester.stdout.on('data', function (data) {
+        console.log('stdout: ' + data.toString());
+    });
+
+    harvester.stderr.on('data', function (data) {
+        console.log('stderr: ' + data.toString());
+    });
+
+    harvester.on('exit', function (code) {
+        console.log('child process exited with code ' + code.toString());
+    });    
     console.log("Re-spawned harvester");
 }
 

--- a/configGen/run_harvester.js
+++ b/configGen/run_harvester.js
@@ -132,7 +132,7 @@ function startHarvester() {
     });
 
     harvester.on('exit', function (code) {
-        console.log('child process exited with code ' + code.toString());
+        console.log('child process exited with code ', code);
     });    
     console.log("Re-spawned harvester");
 }

--- a/configGen/run_harvester.js
+++ b/configGen/run_harvester.js
@@ -58,10 +58,13 @@ function refreshConfig() {
             if (logio_streamPrefix) { name = `${logio_streamPrefix}${name}`; }
             let logPath = c.data.LogPath;
 
-            config[name] = {
-                name: name,
-                path: logPath
-            };
+            if (!config[name]) {
+                config[name] = {
+                    name: name,
+                    path: []
+                };
+            }
+            config[name].path.push(logPath);
         }
         return config;
     }).then(generateConfigFile);
@@ -74,7 +77,13 @@ exports.config = {
     logStreams: {`;
     for (let stream of Object.keys(config)) {
         configFile += `
-        ${JSON.stringify(stream)}: [${JSON.stringify(config[stream].path)}],`;
+        ${JSON.stringify(stream)}: [`;
+        for (let p of config[stream].path) {
+            configFile += `
+            ${JSON.stringify(p)},`;
+        }
+        configFile += `
+        ],`;
     }
 
     configFile += `
@@ -88,7 +97,7 @@ exports.config = {
     return configFile;
 }
 
-function updateConfig(msg) {
+let updateConfig = function updateConfig(msg) {
     if (msg) {
         console.warn("Message from docker:", msg);
     }

--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -8,9 +8,8 @@ if [ "$1" = 'logio' ]; then
   source /opt/logio/serversetup.sh
   log.io-server
 elif [ "$1" = 'harvester' ]; then
-  source /opt/logio/harvestersetup.sh
-  printHarvesterConfigFile
-  log.io-harvester
+  cd /opt/configGen
+  node run_harvester.js
 else
   exec "$@"
 fi


### PR DESCRIPTION
Hi,

You probably won't actually consider this ready to merge, but I thought I'd pass it along in case you're interested; it is 100% working and we're using it in production.

I use the following script to start it:

```
#!/usr/bin/env bash
DOCKER_IMG=logio
CNAME=logio_harvester
docker pull $DOCKER_IMG
docker stop $CNAME
docker rm $CNAME
docker run -d \
    -v /var/run/docker.sock:/tmp/docker.sock:ro \
    -v /var/lib/docker/containers:/var/lib/docker/containers \
    -e LOGIO_HARVESTER_NODENAME=`hostname -f` \
    -e LOGIO_HARVESTER_MASTER_HOST=172.16.0.50 \
    --user root \
    --restart=always \
    --name $CNAME \
    $DOCKER_IMG harvester
```

When it starts it queries docker.sock to get a list of all running containers and their log file; it allows the container to override the stream name by setting the "LOGIO_STREAM" variable on the container if desired. There are some other options in there as well.

If a container is started or stopped it will automatically update the config file and restart the harvester.